### PR TITLE
Rediseño del sitio con Astro + acento morado azulado

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -97,3 +97,24 @@ con nodos/aristas precomputados en `graph.json`.
 
 > El NLP de A alimenta el grafo de B: hacer A primero deja los datos listos.
 > Reto: agregar un paso de Python al build (local o `setup-python` en Actions).
+
+### Template reutilizable para otros — 🤖 técnico
+
+Convertir el sitio en un **template de Astro** para que más gente (sobre todo en
+español) pueda lanzar uno igual, gratis y sin dependencias de pago. Astro ya
+soporta esto: se usa con "Use this template" en GitHub o
+`npm create astro@latest -- --template <repo>`.
+
+Pasos:
+
+1. **Repo separado** (no `jabud.github.io`, que tiene contenido personal), ej.
+   `resoluble-astro-theme`.
+2. **Genericizar** el contenido (CV, nombre, redes, notas/proyectos → placeholders).
+3. **Centralizar la config** en un solo archivo (ej. `src/site.config.ts`: nombre,
+   marca, descripción, redes, nav) del que lean los componentes. _(el grueso del
+   trabajo)_
+4. **README + licencia** (MIT).
+5. _(Opcional)_ Demo en vivo, capturas y subirlo al directorio de temas de Astro.
+
+Idea: construir el propio sitio personal **desde** el template, para mantener una
+sola base. Esfuerzo: unas horas para una versión usable; 1–2 días para una pulida.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -22,11 +22,11 @@
   --fg: #1a1a1a;
   --muted: #6b7280;
   --border: #e5e7eb;
-  --accent: #7f00ff; /* violeta base #7f00ff — versión light */
+  --accent: #5f00ff; /* morado azulado #5f00ff — versión light */
   --code-bg: #f4f4f5;
   --hover-bg: #f3f4f6;
   --hover-border: #000000; /* máximo contraste en hover: negro puro */
-  --prompt: #7f00ff;
+  --prompt: #5f00ff;
 }
 
 /* Dark forzado por el toggle */
@@ -35,11 +35,11 @@
   --fg: #e8e8ea;
   --muted: #9ca3af;
   --border: #26262b;
-  --accent: #b366ff; /* violeta #7f00ff aclarado para dark */
+  --accent: #8870ff; /* morado azulado #5f00ff aclarado para dark */
   --code-bg: #1a1a1e;
   --hover-bg: #1a1a1e;
   --hover-border: #ffffff; /* máximo contraste en hover: blanco puro */
-  --prompt: #b366ff;
+  --prompt: #8870ff;
 }
 
 /* Dark por preferencia del sistema (si no hay override claro) */
@@ -49,11 +49,11 @@
     --fg: #e8e8ea;
     --muted: #9ca3af;
     --border: #26262b;
-    --accent: #b366ff;
+    --accent: #8870ff;
     --code-bg: #1a1a1e;
     --hover-bg: #1a1a1e;
     --hover-border: #ffffff;
-    --prompt: #b366ff;
+    --prompt: #8870ff;
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,7 +35,7 @@
   --fg: #e8e8ea;
   --muted: #9ca3af;
   --border: #26262b;
-  --accent: #8870ff; /* morado azulado #5f00ff aclarado para dark */
+  --accent: #8870ff; /* morado azulado #8870ff (derivado de #5f00ff) — versión dark */
   --code-bg: #1a1a1e;
   --hover-bg: #1a1a1e;
   --hover-border: #ffffff; /* máximo contraste en hover: blanco puro */


### PR DESCRIPTION
## Resumen

Trae a `master` el rediseño del sitio personal con Astro (app-shell tipo Databricks) y el ajuste final de color de acento.

## Cambios

- Reconstrucción del sitio con Astro: app-shell (header + sidebar) con tema claro/oscuro.
- Ajustes de color de acento: morado azulado **`#5F00FF`** en claro y **`#8870FF`** en oscuro (aclarado para buen contraste sobre el fondo oscuro).
- Idea de plantilla Astro reutilizable agregada al roadmap.

## Notas

- El color oscuro `#8870FF` mantiene el carácter morado pero tira al azul, con contraste cómodo para enlaces (~5.3:1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)